### PR TITLE
feat: Input 컴포넌트 추가 및 animate hoc 수정

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -44,7 +44,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-turbo-
 
-      # 6. Storybook 빌드 + Chromatic 업로드
+      # 6. 패키지 빌드 (Storybook에서 import하는 패키지 사전 빌드)
+      - name: 🔨 Build packages
+        run: pnpm build
+
+      # 7. Storybook 빌드 + Chromatic 업로드
       - name: 🎨 Build & publish Storybook
         id: chromatic
         uses: chromaui/action@v1
@@ -53,7 +57,7 @@ jobs:
           buildScriptName: build-storybook
           exitOnceUploaded: true
 
-      # 7. GitHub Actions Summary에 결과 요약 출력
+      # 8. GitHub Actions Summary에 결과 요약 출력
       # CI 실행 결과를 한눈에 볼 수 있도록 표 형태로 정리
       - name: 📊 Publish Storybook summary
         run: |

--- a/packages/animate/src/components/animated-message.tsx
+++ b/packages/animate/src/components/animated-message.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { AnimatePresence, motion } from 'motion/react';
+
+/**
+ * AnimatedMessage — 메시지의 등장/퇴장에 fade + slide 애니메이션을 적용하는 래퍼
+ *
+ * children이 있으면 fade+slide로 나타나고,
+ * children이 없으면(null/undefined/false) AnimatePresence가 exit 애니메이션을 실행한다.
+ *
+ * @example
+ * <AnimatedMessage>
+ *   {error && <InputMessage error>{error}</InputMessage>}
+ * </AnimatedMessage>
+ */
+export function AnimatedMessage({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  return (
+    <AnimatePresence>
+      {children && (
+        <motion.div
+          key="message"
+          initial={{ opacity: 0, height: 0, y: -4 }}
+          animate={{ opacity: 1, height: 'auto', y: 0 }}
+          exit={{ opacity: 0, height: 0, y: -4 }}
+          transition={{ duration: 0.2 }}
+          className="overflow-hidden"
+        >
+          {children}
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/packages/animate/src/context.tsx
+++ b/packages/animate/src/context.tsx
@@ -6,6 +6,7 @@ import { createContext } from 'react';
  */
 type AnimateSlots = {
   Root: React.FC<{ children: React.ReactNode }>;
+  Message: React.FC<{ children: React.ReactNode }>;
 };
 
 /** 애니메이션 없이 children만 반환하는 기본 래퍼 */
@@ -20,4 +21,5 @@ const noop = ({ children }: { children: React.ReactNode }) => (
  */
 export const AnimateContext = createContext<AnimateSlots>({
   Root: noop,
+  Message: noop,
 });

--- a/packages/animate/src/index.ts
+++ b/packages/animate/src/index.ts
@@ -1,4 +1,5 @@
 export { AnimateContext } from './context';
 export { AnimateProvider } from './provider';
 export { withAnimate } from './with-animate';
+export { AnimatedMessage } from './components/animated-message';
 export * from './presets';

--- a/packages/animate/src/presets/form.tsx
+++ b/packages/animate/src/presets/form.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { AnimatePresence, motion } from 'motion/react';
+
+/**
+ * formPreset - 폼 입력 요소에 적합한 애니메이션 프리셋
+ *
+ * 적용 대상: Input, Textarea, Select 등 폼 요소
+ */
+export const formPreset = {
+  /**
+   * Message 슬롯 - 에러/헬프 메시지를 감싸는 애니메이션 래퍼
+   * message가 나타날 때 fade + slide 효과
+   */
+  Message: ({ children }: { children: React.ReactNode }) => (
+    <AnimatePresence mode="wait">
+      {children && (
+        <motion.div
+          key="message"
+          initial={{ opacity: 0, height: 0, y: -4 }}
+          animate={{ opacity: 1, height: 'auto', y: 0 }}
+          exit={{ opacity: 0, height: 0, y: -4 }}
+          transition={{ duration: 0.2 }}
+          className="overflow-hidden"
+        >
+          {children}
+        </motion.div>
+      )}
+    </AnimatePresence>
+  ),
+};

--- a/packages/animate/src/presets/index.ts
+++ b/packages/animate/src/presets/index.ts
@@ -1,2 +1,3 @@
 export * from './types';
 export * from './press';
+export * from './form';

--- a/packages/animate/src/presets/types.ts
+++ b/packages/animate/src/presets/types.ts
@@ -1,2 +1,2 @@
 /** 사용 가능한 애니메이션 프리셋 이름 */
-export type AnimatePreset = 'none' | 'press';
+export type AnimatePreset = 'none' | 'press' | 'form';

--- a/packages/animate/src/provider.tsx
+++ b/packages/animate/src/provider.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { AnimateContext } from './context';
+import { formPreset } from './presets/form';
 import { pressPreset } from './presets/press';
 import type { AnimatePreset } from './presets/types';
 
@@ -13,9 +14,12 @@ const noop = ({ children }: { children: React.ReactNode }) => (
  * 프리셋 이름 → 실제 슬롯 매핑
  * 새 프리셋 추가 시 여기에 등록
  */
+const defaults = { Root: noop, Message: noop };
+
 const PRESETS = {
-  none: { Root: noop },
-  press: pressPreset,
+  none: defaults,
+  press: { ...defaults, ...pressPreset },
+  form: { ...defaults, ...formPreset },
 };
 
 /**

--- a/packages/animate/src/with-animate.tsx
+++ b/packages/animate/src/with-animate.tsx
@@ -1,31 +1,42 @@
 'use client';
 
+import { useContext } from 'react';
+import { AnimateContext } from './context';
 import { AnimateProvider } from './provider';
 import type { AnimatePreset } from './presets/types';
 
 /**
- * withAnimate - 컴포넌트에 애니메이션을 주입하는 HOC
+ * Root 슬롯을 Context에서 읽어서 children을 감싸는 내부 컴포넌트
+ * AnimateProvider 안에서 렌더되어야 Context에 접근 가능
+ */
+function RootSlot({ children }: { children: React.ReactNode }) {
+  const { Root } = useContext(AnimateContext);
+  return <Root>{children}</Root>;
+}
+
+/**
+ * withAnimate - 컴포넌트에 애니메이션 Root 슬롯을 주입하는 HOC
  *
- * @param Component - 애니메이션을 적용할 원본 컴포넌트
- * @param preset - 적용할 애니메이션 프리셋 ('none' | 'press')
- * @returns 애니메이션이 주입된 새 컴포넌트
+ * 내부적으로 AnimateProvider → RootSlot → Component 순으로 감싸서
+ * 프리셋의 Root 슬롯이 실제로 적용된다.
  *
  * @example
  * const PressButton = withAnimate(Button, 'press');
  * <PressButton>클릭</PressButton>
+ * // → pressPreset.Root(motion.div whileTap)가 Button을 감쌈
  */
 export function withAnimate<P extends object>(
   Component: React.ComponentType<P>,
   preset: AnimatePreset = 'none',
 ) {
-  // AnimateProvider로 감싸서 Context에 preset 주입
   const Wrapped = (props: P) => (
     <AnimateProvider preset={preset}>
-      <Component {...props} />
+      <RootSlot>
+        <Component {...props} />
+      </RootSlot>
     </AnimateProvider>
   );
 
-  // React DevTools에서 withAnimate(Button)으로 표시
   Wrapped.displayName = `withAnimate(${Component.displayName || Component.name})`;
   return Wrapped;
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poodle-kit/ui",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "React UI component library with Tailwind CSS",
   "author": "",
   "license": "MIT",

--- a/packages/ui/src/components/button/button.stories.tsx
+++ b/packages/ui/src/components/button/button.stories.tsx
@@ -1,6 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { motion } from 'motion/react';
+import { withAnimate } from '@poodle-kit/animate';
 import { Button } from './button';
+
+/** press 프리셋 적용 — withAnimate HOC */
+const PressButton = withAnimate(Button, 'press');
 
 const meta: Meta<typeof Button> = {
   title: 'Components/Button',
@@ -141,47 +144,19 @@ export const Disabled: Story = {
   args: { disabled: true, children: 'Disabled' },
 };
 
-/** Press 애니메이션 적용 버튼 */
+/** press 프리셋 — withAnimate HOC로 눌림 애니메이션 적용 */
 export const WithPressAnimation: Story = {
-  render: (args) => (
-    <motion.div
-      whileTap={{ scale: 0.95 }}
-      transition={{ duration: 0.1 }}
-      style={{ display: 'inline-block' }}
-    >
-      <Button {...args}>눌러보세요</Button>
-    </motion.div>
-  ),
+  render: (args) => <PressButton {...args}>눌러보세요</PressButton>,
 };
 
-/** 다양한 버튼에 Press 애니메이션 적용 */
+/** 다양한 variant에 press 프리셋 적용 */
 export const PressAnimationVariants: Story = {
   render: () => (
     <div className="flex flex-wrap gap-3">
-      <motion.div
-        whileTap={{ scale: 0.95 }}
-        style={{ display: 'inline-block' }}
-      >
-        <Button variant="default">Default</Button>
-      </motion.div>
-      <motion.div
-        whileTap={{ scale: 0.95 }}
-        style={{ display: 'inline-block' }}
-      >
-        <Button variant="secondary">Secondary</Button>
-      </motion.div>
-      <motion.div
-        whileTap={{ scale: 0.95 }}
-        style={{ display: 'inline-block' }}
-      >
-        <Button variant="danger">Danger</Button>
-      </motion.div>
-      <motion.div
-        whileTap={{ scale: 0.95 }}
-        style={{ display: 'inline-block' }}
-      >
-        <Button variant="outline">Outline</Button>
-      </motion.div>
+      <PressButton variant="default">Default</PressButton>
+      <PressButton variant="secondary">Secondary</PressButton>
+      <PressButton variant="danger">Danger</PressButton>
+      <PressButton variant="outline">Outline</PressButton>
     </div>
   ),
 };

--- a/packages/ui/src/components/input/index.ts
+++ b/packages/ui/src/components/input/index.ts
@@ -1,0 +1,5 @@
+export { Input, inputVariants, type InputProps } from './input';
+export {
+  InputMessage,
+  type InputMessageProps,
+} from './input-message';

--- a/packages/ui/src/components/input/input-message.tsx
+++ b/packages/ui/src/components/input/input-message.tsx
@@ -1,0 +1,48 @@
+import type { ReactNode } from 'react';
+import { cn } from '../../lib/cn';
+
+export interface InputMessageProps {
+  /** 표시할 메시지 텍스트 */
+  children: ReactNode;
+  /** true이면 빨간색(에러), false/undefined이면 회색(도움말) */
+  error?: boolean;
+  className?: string;
+}
+
+/**
+ * InputMessage — Input 하단에 표시되는 에러/헬프 메시지 컴포넌트
+ *
+ * Input과 분리된 별도 컴포넌트로, 애니메이션이 필요하면
+ * 이 컴포넌트를 motion.div로 감싸서 사용한다.
+ *
+ * @example
+ * // 기본 사용
+ * <InputMessage error>올바른 이메일을 입력해주세요.</InputMessage>
+ * <InputMessage>8자 이상 입력해주세요.</InputMessage>
+ *
+ * // 애니메이션 적용
+ * <AnimatePresence>
+ *   {error && (
+ *     <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
+ *       <InputMessage error>{error}</InputMessage>
+ *     </motion.div>
+ *   )}
+ * </AnimatePresence>
+ */
+export function InputMessage({
+  children,
+  error,
+  className,
+}: InputMessageProps) {
+  return (
+    <p
+      className={cn(
+        'text-xs',
+        error ? 'text-danger' : 'text-muted-foreground',
+        className,
+      )}
+    >
+      {children}
+    </p>
+  );
+}

--- a/packages/ui/src/components/input/input.stories.tsx
+++ b/packages/ui/src/components/input/input.stories.tsx
@@ -1,0 +1,182 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { AnimatedMessage } from '@poodle-kit/animate';
+import { Input } from './input';
+import { InputMessage } from './input-message';
+
+const meta: Meta<typeof Input> = {
+  title: 'Components/Input',
+  component: Input,
+  parameters: { layout: 'centered' },
+  args: {
+    placeholder: 'Enter text...',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Input>;
+
+export const Playground: Story = {};
+
+export const WithLabel: Story = {
+  args: {
+    label: 'Email',
+    placeholder: 'you@example.com',
+  },
+};
+
+export const States: Story = {
+  render: () => (
+    <div className="flex flex-col gap-4 w-64">
+      <div className="flex flex-col gap-1">
+        <Input label="Default" placeholder="기본 상태" />
+      </div>
+      <div className="flex flex-col gap-1">
+        <Input label="Error" placeholder="에러 상태" error />
+        <InputMessage error>
+          올바른 이메일을 입력해주세요.
+        </InputMessage>
+      </div>
+      <div className="flex flex-col gap-1">
+        <Input label="Success" placeholder="성공 상태" success />
+        <InputMessage>사용 가능한 이메일이에요.</InputMessage>
+      </div>
+    </div>
+  ),
+};
+
+export const WithHelpText: Story = {
+  render: () => (
+    <div className="flex flex-col gap-1 w-64">
+      <Input
+        label="Password"
+        type="password"
+        placeholder="••••••••"
+      />
+      <InputMessage>8자 이상 입력해주세요.</InputMessage>
+    </div>
+  ),
+};
+
+export const Required: Story = {
+  args: {
+    label: 'Email',
+    placeholder: 'you@example.com',
+    required: true,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    label: 'Disabled',
+    value: '수정할 수 없어요',
+    disabled: true,
+  },
+};
+
+export const Sizes: Story = {
+  render: () => (
+    <div className="flex flex-col gap-3 w-64">
+      <Input size="sm" placeholder="Small" />
+      <Input size="default" placeholder="Default" />
+      <Input size="lg" placeholder="Large" />
+    </div>
+  ),
+};
+
+const SearchIcon = () => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+  >
+    <circle cx="11" cy="11" r="8" />
+    <path d="m21 21-4.35-4.35" />
+  </svg>
+);
+
+const EyeIcon = () => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+  >
+    <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+    <circle cx="12" cy="12" r="3" />
+  </svg>
+);
+
+export const WithIcons: Story = {
+  render: () => (
+    <div className="flex flex-col gap-3 w-64">
+      <Input leftIcon={<SearchIcon />} placeholder="검색..." />
+      <Input
+        rightIcon={<EyeIcon />}
+        type="password"
+        placeholder="비밀번호"
+      />
+      <Input
+        leftIcon={<SearchIcon />}
+        rightIcon={<EyeIcon />}
+        placeholder="양쪽 아이콘"
+      />
+    </div>
+  ),
+};
+
+export const WithIconClick: Story = {
+  render: () => {
+    return (
+      <Input
+        rightIcon={<EyeIcon />}
+        type="password"
+        placeholder="비밀번호"
+        onRightIconClick={() => alert('아이콘 클릭!')}
+      />
+    );
+  },
+};
+
+function AnimatedInputDemo() {
+  const [error, setError] = useState<string | undefined>(undefined);
+
+  return (
+    <div className="flex flex-col gap-3 w-64">
+      <div className="flex flex-col gap-1">
+        <Input
+          label="Email"
+          placeholder="you@example.com"
+          error={!!error}
+        />
+        <AnimatedMessage>
+          {error && <InputMessage error>{error}</InputMessage>}
+        </AnimatedMessage>
+      </div>
+      <div className="flex gap-2">
+        <button
+          onClick={() => setError('올바른 이메일을 입력해주세요.')}
+          className="px-3 py-1 text-xs bg-danger text-white rounded"
+        >
+          에러 표시
+        </button>
+        <button
+          onClick={() => setError(undefined)}
+          className="px-3 py-1 text-xs bg-secondary rounded"
+        >
+          에러 제거
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/** 에러 메시지에 fade+slide 애니메이션 적용 */
+export const WithMessageAnimation: Story = {
+  render: () => <AnimatedInputDemo />,
+};

--- a/packages/ui/src/components/input/input.tsx
+++ b/packages/ui/src/components/input/input.tsx
@@ -1,0 +1,172 @@
+import {
+  type InputHTMLAttributes,
+  forwardRef,
+  type ReactNode,
+} from 'react';
+import { cva } from 'class-variance-authority';
+import { cn } from '../../lib/cn';
+
+/**
+ * 상태(state)와 크기(size)에 따른 input 스타일 변형
+ *
+ * state:
+ *   - default: 기본 포커스 링
+ *   - error: 빨간 테두리 + 포커스 링
+ *   - success: 초록 테두리 + 포커스 링
+ */
+const inputVariants = cva(
+  'flex w-full rounded-[var(--radius-md)] border border-input bg-background text-sm placeholder:text-muted-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+  {
+    variants: {
+      size: {
+        default: 'h-10 px-3 py-2',
+        sm: 'h-9 px-2 text-xs',
+        lg: 'h-11 px-4',
+      },
+      state: {
+        default: 'focus-visible:ring-ring',
+        error: 'border-danger focus-visible:ring-danger',
+        success: 'border-success focus-visible:ring-success',
+      },
+    },
+    defaultVariants: {
+      size: 'default',
+      state: 'default',
+    },
+  },
+);
+
+export interface InputProps extends Omit<
+  InputHTMLAttributes<HTMLInputElement>,
+  'size'
+> {
+  /** input 크기 */
+  size?: 'default' | 'sm' | 'lg';
+  /** 라벨 텍스트 */
+  label?: string;
+  /** 에러 상태 — 빨간 테두리, aria-invalid 자동 설정 */
+  error?: boolean;
+  /** 성공 상태 — 초록 테두리 */
+  success?: boolean;
+  /** 좌측 아이콘 (ReactNode) */
+  leftIcon?: ReactNode;
+  /** 우측 아이콘 (ReactNode) */
+  rightIcon?: ReactNode;
+  /** 좌측 아이콘 클릭 핸들러 — 없으면 아이콘이 클릭 불가 */
+  onLeftIconClick?: () => void;
+  /** 우측 아이콘 클릭 핸들러 — 없으면 아이콘이 클릭 불가 */
+  onRightIconClick?: () => void;
+  /** wrapper div에 적용할 className */
+  className?: string;
+  /** input 요소에만 적용할 className */
+  inputClassName?: string;
+}
+
+const Input = forwardRef<HTMLInputElement, InputProps>(
+  (
+    {
+      className,
+      inputClassName,
+      size,
+      error,
+      success,
+      label,
+      id,
+      leftIcon,
+      rightIcon,
+      onLeftIconClick,
+      onRightIconClick,
+      required,
+      disabled,
+      ...props
+    },
+    ref,
+  ) => {
+    // error > success > default 우선순위로 state 결정
+    const state = error ? 'error' : success ? 'success' : 'default';
+
+    return (
+      <div className={cn('flex flex-col gap-1', className)}>
+        {/* 라벨 — required이면 * 표시 */}
+        {label && (
+          <label
+            htmlFor={id}
+            className={cn(
+              'text-sm font-medium',
+              disabled && 'opacity-50',
+            )}
+          >
+            {label}
+            {required && (
+              <span className="ml-1 text-danger" aria-label="필수">
+                *
+              </span>
+            )}
+          </label>
+        )}
+
+        {/* input + 아이콘을 감싸는 relative 컨테이너 */}
+        <div className="relative">
+          {/* 좌측 아이콘 — onLeftIconClick 없으면 pointer-events-none */}
+          {leftIcon && (
+            <button
+              type="button"
+              disabled={disabled || !onLeftIconClick}
+              aria-label="left icon"
+              className={cn(
+                'absolute left-3 top-1/2 z-10 -translate-y-1/2',
+                onLeftIconClick && !disabled
+                  ? 'cursor-pointer'
+                  : 'pointer-events-none cursor-default',
+                disabled && 'opacity-50',
+              )}
+              onClick={() => !disabled && onLeftIconClick?.()}
+            >
+              {leftIcon}
+            </button>
+          )}
+
+          <input
+            id={id}
+            ref={ref}
+            required={required}
+            disabled={disabled}
+            // error 상태일 때 스크린리더가 invalid 필드로 인식
+            aria-invalid={error || undefined}
+            className={cn(
+              inputVariants({ size, state }),
+              // 아이콘이 있을 때 텍스트가 아이콘에 가리지 않도록 패딩 추가
+              leftIcon && 'pl-9',
+              rightIcon && 'pr-9',
+              inputClassName,
+            )}
+            {...props}
+          />
+
+          {/* 우측 아이콘 — onRightIconClick 없으면 pointer-events-none */}
+          {rightIcon && (
+            <button
+              type="button"
+              disabled={disabled || !onRightIconClick}
+              aria-label="right icon"
+              className={cn(
+                'absolute right-3 top-1/2 z-10 -translate-y-1/2',
+                onRightIconClick && !disabled
+                  ? 'cursor-pointer'
+                  : 'pointer-events-none cursor-default',
+                disabled && 'opacity-50',
+              )}
+              onClick={() => !disabled && onRightIconClick?.()}
+            >
+              {rightIcon}
+            </button>
+          )}
+        </div>
+      </div>
+    );
+  },
+);
+
+Input.displayName = 'Input';
+
+export { Input, inputVariants };

--- a/packages/ui/src/components/input/input.tsx
+++ b/packages/ui/src/components/input/input.tsx
@@ -111,16 +111,16 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
           {leftIcon && (
             <button
               type="button"
-              disabled={disabled || !onLeftIconClick}
+              disabled={!onLeftIconClick}
               aria-label="left icon"
               className={cn(
                 'absolute left-3 top-1/2 z-10 -translate-y-1/2',
-                onLeftIconClick && !disabled
+                onLeftIconClick
                   ? 'cursor-pointer'
                   : 'pointer-events-none cursor-default',
                 disabled && 'opacity-50',
               )}
-              onClick={() => !disabled && onLeftIconClick?.()}
+              onClick={onLeftIconClick}
             >
               {leftIcon}
             </button>
@@ -147,16 +147,16 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
           {rightIcon && (
             <button
               type="button"
-              disabled={disabled || !onRightIconClick}
+              disabled={!onRightIconClick}
               aria-label="right icon"
               className={cn(
                 'absolute right-3 top-1/2 z-10 -translate-y-1/2',
-                onRightIconClick && !disabled
+                onRightIconClick
                   ? 'cursor-pointer'
                   : 'pointer-events-none cursor-default',
                 disabled && 'opacity-50',
               )}
-              onClick={() => !disabled && onRightIconClick?.()}
+              onClick={onRightIconClick}
             >
               {rightIcon}
             </button>

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -5,6 +5,16 @@ import './tailwind.css';
 export { Button, buttonVariants } from './components/button';
 export type { ButtonProps } from './components/button';
 
+export {
+  Input,
+  inputVariants,
+  InputMessage,
+} from './components/input';
+export type {
+  InputProps,
+  InputMessageProps,
+} from './components/input';
+
 // Theme
 export {
   ThemeProvider,

--- a/packages/ui/tsup.config.ts
+++ b/packages/ui/tsup.config.ts
@@ -1,4 +1,6 @@
 import { defineConfig } from 'tsup';
+import { copyFileSync, mkdirSync, existsSync } from 'fs';
+import { join } from 'path';
 
 export default defineConfig({
   entry: [
@@ -16,5 +18,12 @@ export default defineConfig({
   loader: {
     '.css': 'css',
   },
-  onSuccess: 'cp -r src/theme/*.css dist/theme/',
+  onSuccess: async () => {
+    const destDir = join('dist', 'theme');
+    if (!existsSync(destDir)) mkdirSync(destDir, { recursive: true });
+    copyFileSync(
+      join('src', 'theme', 'theme.css'),
+      join(destDir, 'theme.css'),
+    );
+  },
 });


### PR DESCRIPTION
## 🐕 PR 개요

Input, InputMessage 컴포넌트를 추가하고, animate 패키지의 withAnimate HOC 버그를 수정했습니다
UI와 애니메이션이 완전히 분리하여 필요할 때만 AnimatedMessage로 감싸서 애니메이션을 추가할 수 있습니다.

## 🦮 변경 유형

- [x] ✨ 신규 컴포넌트 추가
- [x] 🐛 버그 수정
- [x] 🔧 설정 파일 변경 (빌드, 린트, 테스트 등)
- [x] 🚀 배포/릴리즈 관련 작업

## 🐩 주요 변경 사항

### @poodle-kit/animate

- **withAnimate HOC 버그 수정**: 기존에는 AnimateProvider만 감싸고 컴포넌트가 Context를
  읽지 않아 프리셋이 실제로 적용되지 않던 문제 수정 -> RootSlot 컴포넌트를 추가해 Context의
  Root 슬롯이 실제로 컴포넌트를 감싸도록 수정
- **AnimateContext에 Message 슬롯 추가**: 에러/헬프 메시지용 슬롯
- **form 프리셋 추가**: 에러 메시지 fade + slide 애니메이션
- **AnimatedMessage 컴포넌트 추가**: AnimatePresence + motion.div 보일러플레이트를 래핑한 컴포넌트

### @poodle-kit/ui

- **Input 컴포넌트 추가**: label, error/success 상태, size, leftIcon/rightIcon,
  aria-invalid, forwardRef 지원. animate 의존성 없는 순수 UI
- **InputMessage 컴포넌트 추가**: error면 빨간색, 기본은 회색인 메시지 컴포넌트
- **button.stories.tsx 수정**: motion 직접 사용 -> withAnimate HOC로 교체
- **tsup.config.ts 수정**: tsup 빌드 후 theme.css 복사 방식을 Windows 호환 방식으로 수정
- **버전 0.2.0 업데이트** 
- 
### CI

- **chromatic.yml 수정**: Storybook 빌드 전 `pnpm build` step 추가
  - Storybook 스토리에서 `@poodle-kit/animate`를 import하는데
    CI 환경에는 dist가 없어서 빌드 실패 문제를 수정
  - 의존성 설치 → 패키지 빌드 → Storybook 빌드 순서로 실행되도록 변경

## 🐕‍🦺 테스트 정보

- [x] 스토리북 확인
- [x] 로컬 환경에서 직접 테스트

### 테스트 방법

1. `pnpm --filter @poodle-kit/animate build`
2. `pnpm storybook` 실행
3. Components/Input 스토리 확인 (Playground, States, WithIcons, WithMessageAnimation)
4. Components/Button > WithPressAnimation 확인 (눌림 애니메이션 동작 확인)

## 🦴 체크리스트

- [x] 로컬에서 빌드가 정상적으로 완료됨
- [x] lint / typecheck 오류 없음
- [x] 기존 기능에 영향을 주지 않음
- [x] 불필요한 console.log, 주석 제거
- [x] 네이밍 및 코드 컨벤션 준수

## 🐶 스크린샷 / 미리보기
자세한 내용은 chromaticui test에서 확인하실 수 있습니다.

<img width="542" height="320" alt="스크린샷 2026-02-26 114937" src="https://github.com/user-attachments/assets/070ed225-d6a9-49e8-a307-0f052771f23b" />
<img width="606" height="573" alt="스크린샷 2026-02-26 114916" src="https://github.com/user-attachments/assets/88e1be47-ac83-4cc1-8b83-0b983111bfe6" />
<img width="530" height="382" alt="스크린샷 2026-02-26 114928" src="https://github.com/user-attachments/assets/48d4fb2e-1e82-40e7-b600-ab47e07e463a" />


## 🦴 추가 정보

UI ↔ 애니메이션 의존성 분리 원칙:
- `@poodle-kit/ui`는 `@poodle-kit/animate`에 의존하지 않음
- 애니메이션이 필요한 사용자는 `AnimatedMessage`나 `withAnimate`로 직접 감싸서 사용

## 🐾 관련 이슈 / PR

Close #16 
Close #17 
