### PR TITLE
이미지 업로더 컴포넌트 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ Thumbs.db
 
 # optional caches
 .vite/
+
+## AI
+CLAUDE.md

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poodle-kit/ui",
-  "version": "0.1.1",
+  "version": "0.3.0",
   "description": "React UI component library with Tailwind CSS",
   "author": "",
   "license": "MIT",

--- a/packages/ui/src/components/image-uploader/image-uploader.stories.tsx
+++ b/packages/ui/src/components/image-uploader/image-uploader.stories.tsx
@@ -1,0 +1,247 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { ImageUploader } from './image-uploader';
+import type {
+  ExistingImage,
+  ImageUploaderError,
+} from './use-image-uploader';
+
+// ─── Mock Data ────────────────────────────────────────────────────────────────
+
+const mockExistingImages: ExistingImage[] = [
+  {
+    id: 1,
+    url: 'https://picsum.photos/seed/poodle1/200/200',
+    sequence: 1,
+  },
+  {
+    id: 2,
+    url: 'https://picsum.photos/seed/poodle2/200/200',
+    sequence: 2,
+  },
+];
+
+// ─── Meta ─────────────────────────────────────────────────────────────────────
+
+const meta: Meta<typeof ImageUploader> = {
+  title: 'Components/ImageUploader',
+  component: ImageUploader,
+  parameters: { layout: 'padded' },
+  args: {
+    maxImages: 4,
+    disabled: false,
+    layout: 'row',
+  },
+  argTypes: {
+    layout: {
+      control: 'radio',
+      options: ['row', 'grid'],
+    },
+    maxImages: {
+      control: { type: 'number', min: 1, max: 10 },
+    },
+    maxSizeMb: {
+      control: { type: 'number', min: 1, max: 100 },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ImageUploader>;
+
+// ─── Stateful Story Components ────────────────────────────────────────────────
+
+function DefaultStory() {
+  const [files, setFiles] = useState<File[]>([]);
+  return (
+    <div className="flex flex-col gap-4">
+      <ImageUploader
+        onFileSelect={setFiles}
+        onError={(err: ImageUploaderError) => alert(err.message)}
+      />
+      <p className="text-sm text-muted-foreground">
+        선택된 파일: {files.length}개
+      </p>
+    </div>
+  );
+}
+
+function WithExistingImagesStory() {
+  const [files, setFiles] = useState<File[]>([]);
+  const [deletedIds, setDeletedIds] = useState<
+    Array<number | string>
+  >([]);
+  return (
+    <div className="flex flex-col gap-4">
+      <ImageUploader
+        initialImages={mockExistingImages}
+        onFileSelect={setFiles}
+        onDeleteExisting={setDeletedIds}
+        onError={(err: ImageUploaderError) => alert(err.message)}
+      />
+      <div className="text-sm text-muted-foreground space-y-1">
+        <p>새 파일: {files.length}개</p>
+        <p>삭제된 id: [{deletedIds.join(', ')}]</p>
+      </div>
+    </div>
+  );
+}
+
+// ─── Stories ──────────────────────────────────────────────────────────────────
+
+/** Controls 패널로 모든 props를 조작할 수 있어요 */
+export const Playground: Story = {};
+
+/** 기본 빈 상태 */
+export const Default: Story = {
+  render: () => <DefaultStory />,
+};
+
+/** 수정 모드 — 서버에서 받은 기존 이미지와 함께 렌더링돼요 */
+export const WithExistingImages: Story = {
+  render: () => <WithExistingImagesStory />,
+};
+
+/** grid layout — 이미지가 줄바꿈되며 격자로 배치돼요 */
+export const GridLayout: Story = {
+  render: () => (
+    <ImageUploader
+      initialImages={mockExistingImages}
+      layout="grid"
+      maxImages={6}
+      onError={(err: ImageUploaderError) => alert(err.message)}
+    />
+  ),
+};
+
+/** 이미지 개수 제한 — 4장이 채워지면 추가 버튼이 사라져요 */
+export const MaxImagesReached: Story = {
+  render: () => (
+    <ImageUploader
+      initialImages={[
+        {
+          id: 1,
+          url: 'https://picsum.photos/seed/a/200/200',
+          sequence: 1,
+        },
+        {
+          id: 2,
+          url: 'https://picsum.photos/seed/b/200/200',
+          sequence: 2,
+        },
+        {
+          id: 3,
+          url: 'https://picsum.photos/seed/c/200/200',
+          sequence: 3,
+        },
+        {
+          id: 4,
+          url: 'https://picsum.photos/seed/d/200/200',
+          sequence: 4,
+        },
+      ]}
+      maxImages={4}
+      onError={(err: ImageUploaderError) => alert(err.message)}
+    />
+  ),
+};
+
+/** 파일 크기 제한 — 5MB를 초과하면 onError가 호출돼요 */
+export const WithSizeLimit: Story = {
+  render: () => (
+    <div className="flex flex-col gap-2">
+      <ImageUploader
+        maxSizeMb={5}
+        onError={(err: ImageUploaderError) => {
+          console.error('[ImageUploader Error]', err);
+          if (err.type === 'MAX_SIZE') alert(err.message);
+        }}
+      />
+      <p className="text-sm text-muted-foreground">
+        5MB 이하 이미지만 추가할 수 있어요
+      </p>
+    </div>
+  ),
+};
+
+/** disabled 상태 — 모든 인터랙션이 비활성화돼요 */
+export const Disabled: Story = {
+  render: () => (
+    <ImageUploader initialImages={mockExistingImages} disabled />
+  ),
+};
+
+/** placeholder prop — 추가 버튼의 내용을 커스텀할 수 있어요 */
+export const CustomPlaceholder: Story = {
+  render: () => (
+    <ImageUploader
+      placeholder={
+        <span className="text-xs font-medium text-center leading-tight px-1">
+          사진
+          <br />
+          추가
+        </span>
+      }
+      onError={(err: ImageUploaderError) => alert(err.message)}
+    />
+  ),
+};
+
+/** onError 콜백 — 에러 타입별 분기 처리 예시 */
+export const ErrorHandling: Story = {
+  render: () => {
+    const handleError = (err: ImageUploaderError) => {
+      switch (err.type) {
+        case 'MAX_IMAGES':
+          console.warn('최대 이미지 초과:', err.maxImages);
+          break;
+        case 'MAX_SIZE':
+          console.warn(
+            '파일 크기 초과:',
+            err.file.name,
+            err.maxSizeMb + 'MB',
+          );
+          break;
+        case 'INVALID_TYPE':
+          console.warn('지원하지 않는 형식:', err.file.name);
+          break;
+      }
+    };
+
+    return (
+      <ImageUploader
+        maxImages={2}
+        maxSizeMb={1}
+        accept="image/jpeg,image/png"
+        onError={handleError}
+      />
+    );
+  },
+};
+
+/** useImageUploader hook 직접 사용 예시 */
+export const HeadlessHookUsage: Story = {
+  render: () => {
+    // 실제 코드에서는 useImageUploader를 직접 import해서 사용해요:
+    // import { useImageUploader } from '@poodle-kit/ui';
+    return (
+      <div className="p-4 rounded-[var(--radius-lg)] border border-border bg-muted">
+        <p className="text-sm text-muted-foreground mb-2">
+          <code className="text-xs bg-background px-1 py-0.5 rounded">
+            useImageUploader
+          </code>{' '}
+          hook으로 UI를 완전히 커스텀할 수 있어요.
+        </p>
+        <ImageUploader
+          placeholder={
+            <span className="text-[11px] font-semibold text-primary">
+              드래그
+              <br />
+              or 클릭
+            </span>
+          }
+        />
+      </div>
+    );
+  },
+};

--- a/packages/ui/src/components/image-uploader/image-uploader.stories.tsx
+++ b/packages/ui/src/components/image-uploader/image-uploader.stories.tsx
@@ -225,7 +225,7 @@ export const HeadlessHookUsage: Story = {
     // 실제 코드에서는 useImageUploader를 직접 import해서 사용해요:
     // import { useImageUploader } from '@poodle-kit/ui';
     return (
-      <div className="p-4 rounded-[var(--radius-lg)] border border-border bg-muted">
+      <div className="p-4 rounded-lg border border-border bg-muted">
         <p className="text-sm text-muted-foreground mb-2">
           <code className="text-xs bg-background px-1 py-0.5 rounded">
             useImageUploader

--- a/packages/ui/src/components/image-uploader/image-uploader.tsx
+++ b/packages/ui/src/components/image-uploader/image-uploader.tsx
@@ -109,9 +109,9 @@ function AddButton({
       disabled={disabled}
       aria-label={`이미지 추가 (${current}/${max})`}
       className={cn(
-        'flex-shrink-0 w-20 h-20',
+        'shrink-0 w-20 h-20',
         'flex flex-col items-center justify-center gap-1',
-        'rounded-[var(--radius-lg)]',
+        'rounded-lg',
         'border-2 border-dashed border-border',
         'bg-muted text-muted-foreground',
         'cursor-pointer select-none',
@@ -142,12 +142,12 @@ interface ImageItemProps {
 
 function ImageItem({ src, alt, onRemove, disabled }: ImageItemProps) {
   return (
-    <div className="relative flex-shrink-0 w-20 h-20 group/item">
+    <div className="relative shrink-0 w-20 h-20 group/item">
       <img
         src={src}
         alt={alt}
         draggable={false}
-        className="w-full h-full object-cover rounded-[var(--radius-lg)]"
+        className="w-full h-full object-cover rounded-lg"
       />
       {!disabled && (
         <button
@@ -261,7 +261,7 @@ export const ImageUploader = forwardRef<
           aria-label={`이미지 업로더, ${totalCount}/${maxImages}개 선택됨`}
           className={cn(
             imageUploaderVariants({ layout }),
-            'rounded-[var(--radius-lg)] p-1 -ml-1',
+            'rounded-lg p-1 -ml-1',
             'transition-all duration-200',
             isDragActive &&
               'ring-2 ring-primary ring-offset-2 bg-primary/5',

--- a/packages/ui/src/components/image-uploader/image-uploader.tsx
+++ b/packages/ui/src/components/image-uploader/image-uploader.tsx
@@ -4,56 +4,13 @@ import { forwardRef, useId } from 'react';
 import type { ReactNode } from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '../../lib/cn';
+import { PlusIcon, XIcon } from '../../icons';
 import {
   useImageUploader,
   type ExistingImage,
   type NewImageFile,
   type UseImageUploaderOptions,
 } from './use-image-uploader';
-
-// ─── Inline Icons (no external dependency) ───────────────────────────────────
-
-function PlusIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      width="20"
-      height="20"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-      aria-hidden="true"
-    >
-      <path d="M5 12h14" />
-      <path d="M12 5v14" />
-    </svg>
-  );
-}
-
-function XIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      width="12"
-      height="12"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-      aria-hidden="true"
-    >
-      <path d="M18 6 6 18" />
-      <path d="m6 6 12 12" />
-    </svg>
-  );
-}
 
 // ─── CVA Variants ─────────────────────────────────────────────────────────────
 
@@ -168,7 +125,7 @@ function ImageItem({ src, alt, onRemove, disabled }: ImageItemProps) {
             'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1',
           )}
         >
-          <XIcon />
+          <XIcon strokeWidth="2.5" />
         </button>
       )}
     </div>

--- a/packages/ui/src/components/image-uploader/image-uploader.tsx
+++ b/packages/ui/src/components/image-uploader/image-uploader.tsx
@@ -1,0 +1,323 @@
+'use client';
+
+import { forwardRef, useId } from 'react';
+import type { ReactNode } from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '../../lib/cn';
+import {
+  useImageUploader,
+  type ExistingImage,
+  type NewImageFile,
+  type UseImageUploaderOptions,
+} from './use-image-uploader';
+
+// ─── Inline Icons (no external dependency) ───────────────────────────────────
+
+function PlusIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <path d="M5 12h14" />
+      <path d="M12 5v14" />
+    </svg>
+  );
+}
+
+function XIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="12"
+      height="12"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <path d="M18 6 6 18" />
+      <path d="m6 6 12 12" />
+    </svg>
+  );
+}
+
+// ─── CVA Variants ─────────────────────────────────────────────────────────────
+
+const imageUploaderVariants = cva('flex gap-2', {
+  variants: {
+    layout: {
+      /** 가로 스크롤 행 (기본값) */
+      row: 'flex-row flex-nowrap overflow-x-auto',
+      /** 자동 줄바꿈 격자 */
+      grid: 'flex-wrap',
+    },
+  },
+  defaultVariants: { layout: 'row' },
+});
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+export interface ImageUploaderProps
+  extends
+    UseImageUploaderOptions,
+    VariantProps<typeof imageUploaderVariants> {
+  className?: string;
+  /** true이면 모든 인터랙션을 비활성화해요 */
+  disabled?: boolean;
+  /**
+   * 이미지 추가 버튼의 내용을 교체할 수 있어요.
+   * 기본값은 + 아이콘과 현재/최대 개수를 표시해요.
+   */
+  placeholder?: ReactNode;
+}
+
+// ─── Private Sub-components ──────────────────────────────────────────────────
+
+interface AddButtonProps {
+  onClick: () => void;
+  disabled?: boolean;
+  current: number;
+  max: number;
+  children?: ReactNode;
+}
+
+function AddButton({
+  onClick,
+  disabled,
+  current,
+  max,
+  children,
+}: AddButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-label={`이미지 추가 (${current}/${max})`}
+      className={cn(
+        'flex-shrink-0 w-20 h-20',
+        'flex flex-col items-center justify-center gap-1',
+        'rounded-[var(--radius-lg)]',
+        'border-2 border-dashed border-border',
+        'bg-muted text-muted-foreground',
+        'cursor-pointer select-none',
+        'transition-colors duration-150',
+        'hover:bg-accent hover:text-accent-foreground hover:border-border',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+        'disabled:pointer-events-none disabled:opacity-50',
+      )}
+    >
+      {children ?? (
+        <>
+          <PlusIcon className="w-5 h-5" />
+          <span className="text-[10px] font-medium leading-none tabular-nums">
+            {current}/{max}
+          </span>
+        </>
+      )}
+    </button>
+  );
+}
+
+interface ImageItemProps {
+  src: string;
+  alt: string;
+  onRemove: () => void;
+  disabled?: boolean;
+}
+
+function ImageItem({ src, alt, onRemove, disabled }: ImageItemProps) {
+  return (
+    <div className="relative flex-shrink-0 w-20 h-20 group/item">
+      <img
+        src={src}
+        alt={alt}
+        draggable={false}
+        className="w-full h-full object-cover rounded-[var(--radius-lg)]"
+      />
+      {!disabled && (
+        <button
+          type="button"
+          onClick={onRemove}
+          aria-label={`${alt} 삭제`}
+          className={cn(
+            'absolute -top-1.5 -right-1.5',
+            'w-5 h-5 rounded-full',
+            'flex items-center justify-center',
+            'bg-foreground text-background',
+            'transition-all duration-150',
+            'opacity-0 scale-75',
+            'group-hover/item:opacity-100 group-hover/item:scale-100',
+            'group-focus-within/item:opacity-100 group-focus-within/item:scale-100',
+            'hover:scale-110 active:scale-90',
+            'focus-visible:opacity-100 focus-visible:scale-100',
+            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1',
+          )}
+        >
+          <XIcon />
+        </button>
+      )}
+    </div>
+  );
+}
+
+// ─── Main Component ───────────────────────────────────────────────────────────
+
+export const ImageUploader = forwardRef<
+  HTMLDivElement,
+  ImageUploaderProps
+>(
+  (
+    {
+      className,
+      layout,
+      disabled,
+      placeholder,
+      initialImages,
+      maxImages = 4,
+      maxSizeMb,
+      accept,
+      onFileSelect,
+      onDeleteExisting,
+      onError,
+    },
+    ref,
+  ) => {
+    const uid = useId();
+
+    const {
+      existingImages,
+      newImages,
+      totalCount,
+      isDragActive,
+      inputRef,
+      openFilePicker,
+      removeExisting,
+      removeNew,
+      dragHandlers,
+      inputProps,
+    } = useImageUploader({
+      initialImages,
+      maxImages,
+      maxSizeMb,
+      accept,
+      onFileSelect,
+      onDeleteExisting,
+      onError,
+    });
+
+    const canAdd = !disabled && totalCount < maxImages;
+
+    return (
+      <div ref={ref} className={cn('flex flex-col gap-2', className)}>
+        {/* Screen reader live region — count 변경 시 자동 공지 */}
+        <div
+          role="status"
+          aria-live="polite"
+          aria-atomic="true"
+          className="sr-only"
+        >
+          {totalCount > 0
+            ? `이미지 ${totalCount}개 선택됨. 최대 ${maxImages}개까지 추가할 수 있어요.`
+            : `이미지를 추가해주세요. 최대 ${maxImages}개까지 추가할 수 있어요.`}
+        </div>
+
+        {/* Drag 활성 시 screen reader 긴급 공지 */}
+        {isDragActive && (
+          <span role="alert" className="sr-only">
+            파일을 여기에 놓아주세요
+          </span>
+        )}
+
+        {/* 숨겨진 파일 input (탭 순서에서 제외, 버튼이 대신 처리) */}
+        <input
+          ref={inputRef}
+          id={`${uid}-input`}
+          type="file"
+          tabIndex={-1}
+          aria-hidden="true"
+          className="sr-only"
+          disabled={disabled}
+          {...inputProps}
+        />
+
+        {/* Drop zone + 이미지 목록 */}
+        <div
+          role="group"
+          aria-label={`이미지 업로더, ${totalCount}/${maxImages}개 선택됨`}
+          className={cn(
+            imageUploaderVariants({ layout }),
+            'rounded-[var(--radius-lg)] p-1 -ml-1',
+            'transition-all duration-200',
+            isDragActive &&
+              'ring-2 ring-primary ring-offset-2 bg-primary/5',
+          )}
+          {...(canAdd ? dragHandlers : {})}
+        >
+          {/* 이미지 추가 버튼 */}
+          {canAdd && (
+            <AddButton
+              onClick={openFilePicker}
+              disabled={disabled}
+              current={totalCount}
+              max={maxImages}
+            >
+              {placeholder}
+            </AddButton>
+          )}
+
+          {/* 기존 이미지 (sequence 순 정렬) */}
+          {sortBySequence(existingImages).map((img, index) => (
+            <ImageItem
+              key={`existing-${img.id}`}
+              src={img.url}
+              alt={`이미지 ${index + 1}`}
+              onRemove={() => removeExisting(img.id)}
+              disabled={disabled}
+            />
+          ))}
+
+          {/* 새로 선택한 이미지 */}
+          {newImages.map((item, index) => (
+            <ImageItem
+              key={`new-${item.id}`}
+              src={item.preview}
+              alt={`새 이미지 ${existingImages.length + index + 1}`}
+              onRemove={() => removeNew(item.id)}
+              disabled={disabled}
+            />
+          ))}
+        </div>
+      </div>
+    );
+  },
+);
+
+ImageUploader.displayName = 'ImageUploader';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function sortBySequence(images: ExistingImage[]): ExistingImage[] {
+  return [...images].sort(
+    (a, b) => (a.sequence ?? 0) - (b.sequence ?? 0),
+  );
+}
+
+// ─── Exports ──────────────────────────────────────────────────────────────────
+
+export { imageUploaderVariants };
+export type { ExistingImage, NewImageFile };

--- a/packages/ui/src/components/image-uploader/index.ts
+++ b/packages/ui/src/components/image-uploader/index.ts
@@ -1,0 +1,16 @@
+export {
+  ImageUploader,
+  imageUploaderVariants,
+} from './image-uploader';
+export type {
+  ImageUploaderProps,
+  ExistingImage,
+  NewImageFile,
+} from './image-uploader';
+
+export { useImageUploader } from './use-image-uploader';
+export type {
+  UseImageUploaderOptions,
+  UseImageUploaderReturn,
+  ImageUploaderError,
+} from './use-image-uploader';

--- a/packages/ui/src/components/image-uploader/use-image-uploader.ts
+++ b/packages/ui/src/components/image-uploader/use-image-uploader.ts
@@ -1,0 +1,311 @@
+'use client';
+
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import type React from 'react';
+
+// ─── Public Types ────────────────────────────────────────────────────────────
+
+/** 서버에서 받은 기존 이미지 */
+export interface ExistingImage {
+  id: number | string;
+  url: string;
+  /** 이미지 순서 (정렬에 사용) */
+  sequence?: number;
+}
+
+/** 새로 선택한 파일 (미리보기 포함) */
+export interface NewImageFile {
+  file: File;
+  /** `URL.createObjectURL()` 로 생성된 미리보기 URL */
+  preview: string;
+  /** React key / 삭제 식별자 */
+  id: string;
+}
+
+/** 유효성 검사 에러 Union 타입 */
+export type ImageUploaderError =
+  | { type: 'MAX_IMAGES'; message: string; maxImages: number }
+  | {
+      type: 'MAX_SIZE';
+      message: string;
+      maxSizeMb: number;
+      file: File;
+    }
+  | {
+      type: 'INVALID_TYPE';
+      message: string;
+      file: File;
+      accept: string;
+    };
+
+export interface UseImageUploaderOptions {
+  /** 수정 모드에서 서버 이미지를 전달해요 */
+  initialImages?: ExistingImage[];
+  /** 최대 업로드 가능 이미지 수 (기본값: 4) */
+  maxImages?: number;
+  /** 파일 1개의 최대 크기 (MB). 미설정 시 제한 없음 */
+  maxSizeMb?: number;
+  /** 허용할 파일 형식 (기본값: 'image/*') */
+  accept?: string;
+  /** 현재 선택된 전체 File[] 배열이 변경될 때 호출돼요 */
+  onFileSelect?: (files: File[]) => void;
+  /** 기존 이미지가 삭제될 때 삭제된 id 배열을 전달해요 */
+  onDeleteExisting?: (deletedIds: Array<number | string>) => void;
+  /** 유효성 검사 실패 시 호출돼요 (toast 등 직접 처리) */
+  onError?: (error: ImageUploaderError) => void;
+}
+
+export interface UseImageUploaderReturn {
+  /** 삭제되지 않은 기존 이미지 */
+  existingImages: ExistingImage[];
+  /** 새로 선택한 이미지 (미리보기 포함) */
+  newImages: NewImageFile[];
+  /** 기존 + 새 이미지 합산 개수 */
+  totalCount: number;
+  /** 드래그 활성 여부 */
+  isDragActive: boolean;
+  /** 파일 input 요소의 ref */
+  inputRef: React.RefObject<HTMLInputElement>;
+  /** 파일 선택 다이얼로그 열기 */
+  openFilePicker: () => void;
+  /** 기존 이미지 삭제 */
+  removeExisting: (id: number | string) => void;
+  /** 새로 선택한 이미지 삭제 */
+  removeNew: (id: string) => void;
+  /** drop zone에 spread할 drag 이벤트 핸들러 */
+  dragHandlers: {
+    onDragOver: React.DragEventHandler;
+    onDragLeave: React.DragEventHandler;
+    onDrop: React.DragEventHandler;
+  };
+  /** file input에 spread할 props */
+  inputProps: {
+    onChange: React.ChangeEventHandler<HTMLInputElement>;
+    accept: string;
+    multiple: boolean;
+  };
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function matchesAccept(file: File, accept: string): boolean {
+  return accept
+    .split(',')
+    .map((s) => s.trim().toLowerCase())
+    .some((pattern) => {
+      if (pattern === '*' || pattern === '*/*') return true;
+      if (pattern.startsWith('.'))
+        return file.name.toLowerCase().endsWith(pattern);
+      if (pattern.endsWith('/*'))
+        return file.type.startsWith(pattern.slice(0, -2));
+      return file.type === pattern;
+    });
+}
+
+// ─── Hook ────────────────────────────────────────────────────────────────────
+
+export function useImageUploader({
+  initialImages,
+  maxImages = 4,
+  maxSizeMb,
+  accept = 'image/*',
+  onFileSelect,
+  onDeleteExisting,
+  onError,
+}: UseImageUploaderOptions): UseImageUploaderReturn {
+  const [newImages, setNewImages] = useState<NewImageFile[]>([]);
+  const [deletedIds, setDeletedIds] = useState<
+    Array<number | string>
+  >([]);
+  const [isDragActive, setIsDragActive] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // 콜백 refs — 매 렌더 후 갱신해 stale closure 없이 최신 값 참조
+  const onFileSelectRef = useRef(onFileSelect);
+  const onDeleteExistingRef = useRef(onDeleteExisting);
+  const onErrorRef = useRef(onError);
+  useEffect(() => {
+    onFileSelectRef.current = onFileSelect;
+    onDeleteExistingRef.current = onDeleteExisting;
+    onErrorRef.current = onError;
+  });
+
+  // 상태 refs — 콜백 내에서 최신 상태를 직접 읽기 위해 사용
+  const newImagesRef = useRef<NewImageFile[]>([]);
+  const deletedIdsRef = useRef<Array<number | string>>([]);
+  const existingCountRef = useRef(0);
+
+  const existingImages = useMemo(
+    () =>
+      (initialImages ?? []).filter(
+        (img) => !deletedIds.includes(img.id),
+      ),
+    [initialImages, deletedIds],
+  );
+
+  // 렌더 후 refs 동기화
+  useEffect(() => {
+    newImagesRef.current = newImages;
+  }, [newImages]);
+  useEffect(() => {
+    deletedIdsRef.current = deletedIds;
+  }, [deletedIds]);
+  useEffect(() => {
+    existingCountRef.current = existingImages.length;
+  }, [existingImages.length]);
+
+  // 언마운트 시 모든 preview URL 해제
+  useEffect(() => {
+    return () => {
+      newImagesRef.current.forEach((item) =>
+        URL.revokeObjectURL(item.preview),
+      );
+    };
+  }, []);
+
+  const processFiles = useCallback(
+    (files: File[]) => {
+      const currentTotal =
+        existingCountRef.current + newImagesRef.current.length;
+      const onErr = onErrorRef.current;
+      const onSelect = onFileSelectRef.current;
+
+      if (currentTotal >= maxImages) {
+        onErr?.({
+          type: 'MAX_IMAGES',
+          message: `이미지는 최대 ${maxImages}장까지 추가할 수 있어요.`,
+          maxImages,
+        });
+        return;
+      }
+
+      const remainingSlots = maxImages - currentTotal;
+
+      if (files.length > remainingSlots) {
+        onErr?.({
+          type: 'MAX_IMAGES',
+          message: `이미지는 최대 ${maxImages}장까지 추가할 수 있어요.`,
+          maxImages,
+        });
+      }
+
+      const validFiles: NewImageFile[] = [];
+
+      for (const file of files.slice(0, remainingSlots)) {
+        if (!matchesAccept(file, accept)) {
+          onErr?.({
+            type: 'INVALID_TYPE',
+            message: `지원하지 않는 파일 형식이에요.`,
+            file,
+            accept,
+          });
+          continue;
+        }
+
+        if (
+          maxSizeMb !== undefined &&
+          file.size > maxSizeMb * 1024 * 1024
+        ) {
+          onErr?.({
+            type: 'MAX_SIZE',
+            message: `${file.name}의 크기가 ${maxSizeMb}MB를 초과해요.`,
+            maxSizeMb,
+            file,
+          });
+          continue;
+        }
+
+        validFiles.push({
+          file,
+          preview: URL.createObjectURL(file),
+          id: crypto.randomUUID(),
+        });
+      }
+
+      if (validFiles.length === 0) return;
+
+      const next = [...newImagesRef.current, ...validFiles];
+      newImagesRef.current = next;
+      setNewImages(next);
+      onSelect?.(next.map((item) => item.file));
+    },
+    [maxImages, accept, maxSizeMb],
+  );
+
+  const removeExisting = useCallback((id: number | string) => {
+    const next = [...deletedIdsRef.current, id];
+    deletedIdsRef.current = next;
+    setDeletedIds(next);
+    onDeleteExistingRef.current?.(next);
+  }, []);
+
+  const removeNew = useCallback((id: string) => {
+    const current = newImagesRef.current;
+    const toRemove = current.find((item) => item.id === id);
+    if (toRemove) URL.revokeObjectURL(toRemove.preview);
+    const next = current.filter((item) => item.id !== id);
+    newImagesRef.current = next;
+    setNewImages(next);
+    onFileSelectRef.current?.(next.map((item) => item.file));
+  }, []);
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      if (!e.target.files) return;
+      processFiles(Array.from(e.target.files));
+      e.target.value = '';
+    },
+    [processFiles],
+  );
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragActive(true);
+  }, []);
+
+  const handleDragLeave = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    // 자식 요소로 이동하는 경우는 무시
+    if (e.currentTarget.contains(e.relatedTarget as Node)) return;
+    setIsDragActive(false);
+  }, []);
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      setIsDragActive(false);
+      processFiles(Array.from(e.dataTransfer.files));
+    },
+    [processFiles],
+  );
+
+  return {
+    existingImages,
+    newImages,
+    totalCount: existingImages.length + newImages.length,
+    isDragActive,
+    inputRef,
+    openFilePicker: () => inputRef.current?.click(),
+    removeExisting,
+    removeNew,
+    dragHandlers: {
+      onDragOver: handleDragOver,
+      onDragLeave: handleDragLeave,
+      onDrop: handleDrop,
+    },
+    inputProps: {
+      onChange: handleChange,
+      accept,
+      multiple: true,
+    },
+  };
+}

--- a/packages/ui/src/icons/index.tsx
+++ b/packages/ui/src/icons/index.tsx
@@ -1,0 +1,48 @@
+import type { SVGProps } from 'react';
+
+// ─── Base ─────────────────────────────────────────────────────────────────────
+
+type IconProps = SVGProps<SVGSVGElement>;
+
+function createIcon(paths: React.ReactNode, defaultSize = 24) {
+  return function Icon({
+    width = defaultSize,
+    height = defaultSize,
+    ...props
+  }: IconProps) {
+    return (
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width={width}
+        height={height}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+        {...props}
+      >
+        {paths}
+      </svg>
+    );
+  };
+}
+
+// ─── Icons ────────────────────────────────────────────────────────────────────
+
+export const PlusIcon = createIcon(
+  <>
+    <path d="M5 12h14" />
+    <path d="M12 5v14" />
+  </>,
+);
+
+export const XIcon = createIcon(
+  <>
+    <path d="M18 6 6 18" />
+    <path d="m6 6 12 12" />
+  </>,
+  12,
+);

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -5,6 +5,20 @@ import './tailwind.css';
 export { Button, buttonVariants } from './components/button';
 export type { ButtonProps } from './components/button';
 
+export {
+  ImageUploader,
+  imageUploaderVariants,
+  useImageUploader,
+} from './components/image-uploader';
+export type {
+  ImageUploaderProps,
+  ExistingImage,
+  NewImageFile,
+  UseImageUploaderOptions,
+  UseImageUploaderReturn,
+  ImageUploaderError,
+} from './components/image-uploader';
+
 // Theme
 export {
   ThemeProvider,

--- a/packages/ui/tsup.config.ts
+++ b/packages/ui/tsup.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   entry: [
     'src/index.ts',
     'src/components/button/button.tsx',
+    'src/components/image-uploader/image-uploader.tsx',
     'src/theme/index.ts',
     'src/lib/cn.ts',
   ],


### PR DESCRIPTION
## 🐕 PR 개요

`ImageUploader` 컴포넌트와 `useImageUploader` hook을 추가했어요. 이미지 선택, 드래그 앤 드롭, 기존 이미지 수정 모드, 유효성 검사를 하나의 컴포넌트로 처리할 수 있어요.

## 🦮 변경 유형

- [x] ✨ 신규 컴포넌트 추가
- [ ] 🎨 기존 컴포넌트 UI/UX 개선
- [ ] 🧠 로직 변경 / 상태 관리 수정
- [ ] 🐛 버그 수정
- [ ] ♻️ 리팩토링 (기능 변경 없음)
- [ ] 🧪 테스트 추가/수정
- [x] 🔧 설정 파일 변경 (빌드, 린트, 테스트 등)
- [ ] 🏗️ 프로젝트 구조 변경
- [ ] 🚀 배포/릴리즈 관련 작업

## 🐩 주요 변경 사항

### `ImageUploader` 컴포넌트 (`packages/ui/src/components/image-uploader/`)

- **`useImageUploader` hook**: 상태 로직을 완전히 분리한 headless hook이에요. 직접 import해서 커스텀 UI를 만들 수 있어요.
- **`ImageUploader` 컴포넌트**: `forwardRef` + CVA 기반으로 Button/Input 패턴과 동일하게 구현했어요.
- **layout variant**: `row` (가로 스크롤, 기본값) / `grid` (자동 줄바꿈) 두 가지를 지원해요.
- **수정 모드**: `initialImages`로 서버 이미지를 받아 기존 이미지 삭제 추적 (`onDeleteExisting`) 을 지원해요.
- **드래그 앤 드롭**: 외부 라이브러리 없이 네이티브 HTML5 D&D로 구현했어요.
- **유효성 검사**: 파일 개수(`MAX_IMAGES`), 파일 크기(`MAX_SIZE`), 파일 형식(`INVALID_TYPE`)을 `onError` 콜백으로 전달해요. toast 등 에러 처리는 소비자가 직접 해요.
- **접근성**: `role="status"` aria-live 공지, `role="group"` drop zone, 모든 버튼에 `aria-label`, 키보드 내비게이션 지원해요.

### 아이콘 모듈 (`packages/ui/src/icons/index.tsx`)

- `createIcon` factory로 내부 공유 아이콘 모듈을 만들었어요. `SVGProps`를 그대로 넘길 수 있어서 `strokeWidth`, `className` 등 자유롭게 override 가능해요.
- 외부 라이브러리 의존 없이 번들 크기를 유지했어요.

### 빌드 설정

- `tsup.config.ts` entry에 `image-uploader.tsx` 추가했어요.
- `'use client'`는 hooks를 직접 사용하는 파일에만 선택적으로 선언했어요 (`image-uploader.tsx`, `use-image-uploader.ts`, `theme/provider.tsx`, `theme/use-theme.ts`).

### 버전

- `@poodle-kit/ui` `0.2.0` → `0.3.0`

## 🐕‍🦺 테스트 정보

- [ ] 단위 테스트 추가/수정
- [x] 스토리북 확인
- [x] 로컬 환경에서 직접 테스트
- [ ] 테스트 없음 (사유를 아래에 작성)

### 테스트 방법

1. Storybook 실행: `pnpm storybook`
2. `Components/ImageUploader` 스토리 확인
3. **Playground**: Controls 패널로 모든 props 조작
4. **Default**: 파일 선택 / 드래그 앤 드롭 동작 확인
5. **WithExistingImages**: 기존 이미지 삭제 및 새 이미지 추가 확인
6. **GridLayout**: grid variant 확인
7. **MaxImagesReached**: 최대 개수 초과 시 추가 버튼 숨김 확인
8. **WithSizeLimit**: 5MB 초과 파일 선택 시 `onError` 호출 확인
9. **Disabled**: 모든 인터랙션 비활성화 확인
10. 키보드: Tab → Enter로 파일 선택, Tab → Enter로 이미지 삭제

## 🦴 체크리스트

- [x] 로컬에서 빌드가 정상적으로 완료됨
- [x] lint / typecheck 오류 없음
- [ ] 테스트가 모두 통과함
- [x] 기존 기능에 영향을 주지 않음
- [x] 불필요한 console.log, 주석 제거
- [x] 네이밍 및 코드 컨벤션 준수

## 🐶 스크린샷 / 미리보기

### Before

해당 컴포넌트 없음

### After
<img width="398" height="134" alt="image" src="https://github.com/user-attachments/assets/96314eb9-d74a-4e58-9b93-b57b858a01e5" />
<img width="428" height="184" alt="image" src="https://github.com/user-attachments/assets/745b2d6e-2e90-434b-aca1-8464e784ab06" />



## 🦴 추가 정보

**`useImageUploader` hook 직접 사용 예시 (고급)**

```tsx
import { useImageUploader } from '@poodle-kit/ui';

function CustomUploader() {
  const { existingImages, newImages, openFilePicker, removeNew, dragHandlers, inputProps } =
    useImageUploader({ maxImages: 6, onError: (err) => toast.error(err.message) });

  return (
    <div {...dragHandlers}>
      <input type="file" className="sr-only" {...inputProps} />
      <button onClick={openFilePicker}>업로드</button>
      {newImages.map((img) => (
        <img key={img.id} src={img.preview} onClick={() => removeNew(img.id)} />
      ))}
    </div>
  );
}
```

**`'use client'` 정책**

hooks / 브라우저 API를 직접 사용하는 파일에만 선택적으로 선언했어요. `cn`, `Button` 등 순수 유틸/컴포넌트는 Server Component에서도 import 가능해요.

## 🐾 관련 이슈 / PR

Closes #13
