### PR TITLE
[Feat][POK-17] toast 컴포넌트 구현

### DIFF
--- a/packages/ui/src/components/toast/index.ts
+++ b/packages/ui/src/components/toast/index.ts
@@ -1,0 +1,10 @@
+export { toast } from './toast';
+export { Toaster } from './toaster';
+
+export type {
+  Toast,
+  ToastOptions,
+  ToastType,
+  ToastPosition,
+  ToasterProps,
+} from './types';

--- a/packages/ui/src/components/toast/store.ts
+++ b/packages/ui/src/components/toast/store.ts
@@ -52,8 +52,12 @@ export const store = {
     };
   },
 
-  /** 현재 toasts 복사본 반환 (useState 초기값용) */
+  /**
+   * 현재 toasts 참조 반환.
+   * addToast/removeToast는 항상 새 배열로 교체하므로 참조가 안정적이다.
+   * useSyncExternalStore의 getSnapshot으로 사용 시 같은 참조를 반환해야 무한 루프가 발생하지 않음.
+   */
   getToasts(): Toast[] {
-    return [...toasts];
+    return toasts;
   },
 };

--- a/packages/ui/src/components/toast/store.ts
+++ b/packages/ui/src/components/toast/store.ts
@@ -1,0 +1,59 @@
+/**
+ * Toast 전역 store
+ *
+ * React Context 없이 모듈 레벨 변수로 상태를 관리한다.
+ * 앱 전체에서 하나의 인스턴스를 공유하므로 Provider 없이 어디서든 toast() 호출 가능.
+ *
+ * 구조:
+ *   toasts[]      — 현재 표시 중인 토스트 목록
+ *   listeners[]   — 상태 변경 시 호출할 구독자 목록 (Toaster가 등록)
+ *
+ * 흐름:
+ *   addToast / removeToast → emit() → listeners 호출 → Toaster 리렌더
+ */
+
+import type { Toast } from './types';
+
+// React 트리 외부의 모듈 레벨 변수 — 앱 전체 공유
+let toasts: Toast[] = [];
+let listeners: Array<(toasts: Toast[]) => void> = [];
+
+/** 현재 toasts 스냅샷을 모든 구독자에게 전달 */
+function emit() {
+  const snapshot = [...toasts];
+  listeners.forEach((l) => l(snapshot));
+}
+
+export const store = {
+  /** 토스트 추가 후 구독자에게 알림 */
+  addToast(toast: Toast): void {
+    toasts = [...toasts, toast];
+    emit();
+  },
+
+  /** id로 토스트 제거 후 구독자에게 알림 */
+  removeToast(id: string): void {
+    toasts = toasts.filter((t) => t.id !== id);
+    emit();
+  },
+
+  /**
+   * 구독 등록. 반환값(언구독 함수)을 useEffect cleanup에서 호출해야 한다.
+   *
+   * @example
+   * useEffect(() => {
+   *   return store.subscribe(setToasts); // 반환값이 cleanup
+   * }, []);
+   */
+  subscribe(listener: (toasts: Toast[]) => void): () => void {
+    listeners = [...listeners, listener];
+    return () => {
+      listeners = listeners.filter((l) => l !== listener);
+    };
+  },
+
+  /** 현재 toasts 복사본 반환 (useState 초기값용) */
+  getToasts(): Toast[] {
+    return [...toasts];
+  },
+};

--- a/packages/ui/src/components/toast/toast-item.tsx
+++ b/packages/ui/src/components/toast/toast-item.tsx
@@ -1,0 +1,223 @@
+'use client';
+
+/**
+ * ToastItem — 개별 토스트 UI 컴포넌트
+ *
+ * 구조:
+ *   [아이콘?] [제목 + 설명?] [닫기버튼?]
+ *
+ * - icon prop이 있으면 우선 사용, 없으면 type 아이콘으로 대체
+ * - description이 있으면 제목 아래에 작은 글씨로 표시
+ * - dismissible=true 일 때만 닫기 버튼 노출
+ *
+ * 스타일링: shadcn/sonner rich-colors 방식
+ *   - bg-{type}/15 + text-{type} + border-{type}/25
+ *   - default는 bg-background 사용
+ */
+
+import { useEffect } from 'react';
+import { motion } from 'motion/react';
+import { cva } from 'class-variance-authority';
+import { cn } from '../../lib/cn';
+import { store } from './store';
+import type { Toast, ToastType } from './types';
+
+// ─── Type Icons ───────────────────────────────────────────────────────────────
+
+function CheckCircleIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="10" />
+      <path d="m9 12 2 2 4-4" />
+    </svg>
+  );
+}
+
+function XCircleIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="10" />
+      <path d="m15 9-6 6" />
+      <path d="m9 9 6 6" />
+    </svg>
+  );
+}
+
+function TriangleAlertIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z" />
+      <path d="M12 9v4" />
+      <path d="M12 17h.01" />
+    </svg>
+  );
+}
+
+function InfoCircleIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="10" />
+      <path d="M12 16v-4" />
+      <path d="M12 8h.01" />
+    </svg>
+  );
+}
+
+const typeIcons: Partial<Record<ToastType, React.ReactNode>> = {
+  success: <CheckCircleIcon />,
+  error: <XCircleIcon />,
+  warning: <TriangleAlertIcon />,
+  info: <InfoCircleIcon />,
+};
+
+// ─── Variants ─────────────────────────────────────────────────────────────────
+
+const toastVariants = cva(
+  'flex items-start gap-3 w-full rounded-lg border px-4 py-3.5 shadow-sm text-[13px] font-medium leading-5 pointer-events-auto',
+  {
+    variants: {
+      type: {
+        default: 'bg-background text-foreground border-border',
+        success: 'bg-success/15 text-success border-success/25',
+        error: 'bg-danger/15 text-danger border-danger/25',
+        warning: 'bg-warning/15 text-warning border-warning/25',
+        info: 'bg-info/15 text-info border-info/25',
+      },
+    },
+    defaultVariants: { type: 'default' },
+  },
+);
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+interface ToastItemProps {
+  toast: Toast;
+  /** Toaster에서 전달하는 기본 duration. toast 개별 duration이 없을 때 사용 */
+  defaultDuration: number;
+}
+
+export function ToastItem({
+  toast,
+  defaultDuration,
+}: ToastItemProps) {
+  const {
+    id,
+    title,
+    description,
+    icon,
+    type = 'default',
+    duration = defaultDuration,
+    dismissible,
+  } = toast;
+
+  // 자동 소멸 타이머
+  // 마운트 시점에 이미 경과한 시간을 빼고 남은 시간만큼만 대기한다.
+  // → maxToasts 초과로 숨겨졌다가 다시 보여지는 경우에도 정확히 만료됨
+  useEffect(() => {
+    if (!duration || duration === Infinity) return;
+    const elapsed = Date.now() - toast.createdAt;
+    const remaining = Math.max(0, duration - elapsed);
+    const timer = setTimeout(() => store.removeToast(id), remaining);
+    return () => clearTimeout(timer); // unmount 시 타이머 정리
+  }, [id, duration, toast.createdAt]);
+
+  // 좌측 아이콘: icon prop 우선, 없으면 타입 아이콘
+  const leftIcon = icon ?? typeIcons[type as ToastType];
+
+  return (
+    <motion.div
+      layout
+      initial={{ opacity: 0, y: 8, scale: 0.96 }}
+      animate={{ opacity: 1, y: 0, scale: 1 }}
+      exit={{
+        opacity: 0,
+        y: 8,
+        scale: 0.96,
+        transition: { duration: 0.3 },
+      }}
+      transition={{ duration: 0.2, ease: 'easeOut' }}
+      role="alert"
+      aria-live="assertive"
+      aria-atomic="true"
+      className={cn(toastVariants({ type: type as ToastType }))}
+    >
+      {/* 좌측 아이콘 */}
+      {leftIcon && <span className="shrink-0 mt-px">{leftIcon}</span>}
+
+      {/* 콘텐츠: 제목 + 설명 */}
+      <div className="flex-1 min-w-0">
+        <p>{title}</p>
+        {description && (
+          <p className="text-[12px] font-normal opacity-70 mt-0.5">
+            {description}
+          </p>
+        )}
+      </div>
+
+      {/* 닫기 버튼 — dismissible=true 일 때만 표시 */}
+      {dismissible && (
+        <button
+          type="button"
+          aria-label="닫기"
+          onClick={() => store.removeToast(id)}
+          className="shrink-0 mt-px opacity-50 hover:opacity-100 transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <svg
+            width="10"
+            height="10"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M18 6 6 18" />
+            <path d="m6 6 12 12" />
+          </svg>
+        </button>
+      )}
+    </motion.div>
+  );
+}

--- a/packages/ui/src/components/toast/toast-item.tsx
+++ b/packages/ui/src/components/toast/toast-item.tsx
@@ -10,13 +10,16 @@
  * - description이 있으면 제목 아래에 작은 글씨로 표시
  * - dismissible=true 일 때만 닫기 버튼 노출
  *
+ * 애니메이션: CSS @keyframes (motion 의존성 없음)
+ *   - 마운트: animate-toast-enter (theme.css에 정의)
+ *   - 언마운트: exiting 상태 → animate-toast-exit → 300ms 후 store에서 제거
+ *
  * 스타일링: shadcn/sonner rich-colors 방식
  *   - bg-{type}/15 + text-{type} + border-{type}/25
  *   - default는 bg-background 사용
  */
 
-import { useEffect } from 'react';
-import { motion } from 'motion/react';
+import { useCallback, useEffect, useState } from 'react';
 import { cva } from 'class-variance-authority';
 import { cn } from '../../lib/cn';
 import { store } from './store';
@@ -150,6 +153,18 @@ export function ToastItem({
     dismissible,
   } = toast;
 
+  // exiting=true → CSS exit 애니메이션 재생 → 300ms 후 store에서 제거
+  const [exiting, setExiting] = useState(false);
+
+  const dismiss = useCallback(() => setExiting(true), []);
+
+  // exit 애니메이션이 끝난 뒤 실제로 store에서 제거
+  useEffect(() => {
+    if (!exiting) return;
+    const timer = setTimeout(() => store.removeToast(id), 300);
+    return () => clearTimeout(timer);
+  }, [exiting, id]);
+
   // 자동 소멸 타이머
   // 마운트 시점에 이미 경과한 시간을 빼고 남은 시간만큼만 대기한다.
   // → maxToasts 초과로 숨겨졌다가 다시 보여지는 경우에도 정확히 만료됨
@@ -157,29 +172,22 @@ export function ToastItem({
     if (!duration || duration === Infinity) return;
     const elapsed = Date.now() - toast.createdAt;
     const remaining = Math.max(0, duration - elapsed);
-    const timer = setTimeout(() => store.removeToast(id), remaining);
-    return () => clearTimeout(timer); // unmount 시 타이머 정리
-  }, [id, duration, toast.createdAt]);
+    const timer = setTimeout(dismiss, remaining);
+    return () => clearTimeout(timer);
+  }, [id, duration, toast.createdAt, dismiss]);
 
   // 좌측 아이콘: icon prop 우선, 없으면 타입 아이콘
   const leftIcon = icon ?? typeIcons[type as ToastType];
 
   return (
-    <motion.div
-      layout
-      initial={{ opacity: 0, y: 8, scale: 0.96 }}
-      animate={{ opacity: 1, y: 0, scale: 1 }}
-      exit={{
-        opacity: 0,
-        y: 8,
-        scale: 0.96,
-        transition: { duration: 0.3 },
-      }}
-      transition={{ duration: 0.2, ease: 'easeOut' }}
+    <div
       role="alert"
       aria-live="assertive"
       aria-atomic="true"
-      className={cn(toastVariants({ type: type as ToastType }))}
+      className={cn(
+        toastVariants({ type: type as ToastType }),
+        exiting ? 'animate-toast-exit' : 'animate-toast-enter',
+      )}
     >
       {/* 좌측 아이콘 */}
       {leftIcon && <span className="shrink-0 mt-px">{leftIcon}</span>}
@@ -199,7 +207,7 @@ export function ToastItem({
         <button
           type="button"
           aria-label="닫기"
-          onClick={() => store.removeToast(id)}
+          onClick={dismiss}
           className="shrink-0 mt-px opacity-50 hover:opacity-100 transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         >
           <svg
@@ -218,6 +226,6 @@ export function ToastItem({
           </svg>
         </button>
       )}
-    </motion.div>
+    </div>
   );
 }

--- a/packages/ui/src/components/toast/toast.stories.tsx
+++ b/packages/ui/src/components/toast/toast.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { Button } from '../Button/button';
+import { Button } from '../button/button';
 import { toast } from './toast';
 import { Toaster } from './toaster';
 import type { ToasterProps } from './types';

--- a/packages/ui/src/components/toast/toast.stories.tsx
+++ b/packages/ui/src/components/toast/toast.stories.tsx
@@ -1,0 +1,274 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Button } from '../Button/button';
+import { toast } from './toast';
+import { Toaster } from './toaster';
+import type { ToasterProps } from './types';
+
+/**
+ * Toaster + toast() 조합 스토리
+ *
+ * 모든 스토리에 <Toaster /> 데코레이터가 적용되어 있다.
+ * args로 position / defaultDuration / maxToasts 조절 가능.
+ */
+const meta: Meta<ToasterProps> = {
+  title: 'Components/Toast',
+  component: Toaster,
+  parameters: { layout: 'centered' },
+  decorators: [
+    (Story, { args }) => (
+      <>
+        <Story />
+        {/* 데코레이터에서 Toaster 렌더 — args 변경 시 즉시 반영 */}
+        <Toaster {...args} />
+      </>
+    ),
+  ],
+  argTypes: {
+    position: {
+      control: 'select',
+      options: [
+        'top-left',
+        'top-center',
+        'top-right',
+        'bottom-left',
+        'bottom-center',
+        'bottom-right',
+      ],
+    },
+    defaultDuration: { control: 'number' },
+    maxToasts: { control: 'number' },
+  },
+  args: {
+    position: 'bottom-right',
+    defaultDuration: 3000,
+    maxToasts: 5,
+  },
+};
+
+export default meta;
+type Story = StoryObj<ToasterProps>;
+
+// ─── Playground ───────────────────────────────────────────────────────────────
+
+/** 버튼을 눌러 각 타입의 토스트를 직접 띄워볼 수 있다 */
+export const Playground: Story = {
+  render: () => (
+    <div className="flex flex-wrap gap-2">
+      <Button onClick={() => toast('기본 알림입니다')}>
+        Default
+      </Button>
+      <Button
+        variant="success"
+        onClick={() => toast.success('저장되었습니다')}
+      >
+        Success
+      </Button>
+      <Button
+        variant="danger"
+        onClick={() => toast.error('오류가 발생했습니다')}
+      >
+        Error
+      </Button>
+      <Button
+        variant="warning"
+        onClick={() => toast.warning('주의가 필요합니다')}
+      >
+        Warning
+      </Button>
+      <Button
+        variant="info"
+        onClick={() => toast.info('참고 사항입니다')}
+      >
+        Info
+      </Button>
+    </div>
+  ),
+};
+
+// ─── With Description ─────────────────────────────────────────────────────────
+
+/** 제목 아래에 부가 설명이 표시된다 */
+export const WithDescription: Story = {
+  render: () => (
+    <div className="flex flex-wrap gap-2">
+      <Button
+        onClick={() =>
+          toast.success('저장되었습니다', {
+            description: '변경 사항이 성공적으로 저장되었습니다.',
+          })
+        }
+      >
+        Success + 설명
+      </Button>
+      <Button
+        variant="danger"
+        onClick={() =>
+          toast.error('업로드 실패', {
+            description: '파일 크기가 10MB를 초과합니다.',
+          })
+        }
+      >
+        Error + 설명
+      </Button>
+      <Button
+        variant="warning"
+        onClick={() =>
+          toast.warning('저장되지 않은 변경 사항', {
+            description: '페이지를 벗어나면 변경 사항이 사라집니다.',
+          })
+        }
+      >
+        Warning + 설명
+      </Button>
+    </div>
+  ),
+};
+
+// ─── Dismissible ──────────────────────────────────────────────────────────────
+
+/** dismissible=true 일 때만 닫기 버튼이 표시된다 */
+export const Dismissible: Story = {
+  render: () => (
+    <div className="flex flex-wrap gap-2">
+      <Button
+        onClick={() =>
+          toast.info('닫기 버튼 있음', {
+            description: '우측의 ✕를 눌러 직접 닫을 수 있습니다.',
+            dismissible: true,
+            duration: Infinity,
+          })
+        }
+      >
+        Dismissible (수동)
+      </Button>
+      <Button
+        variant="success"
+        onClick={() =>
+          toast.success('닫기 버튼 없음', {
+            description: '3초 후 자동으로 사라집니다.',
+          })
+        }
+      >
+        Auto dismiss (닫기 없음)
+      </Button>
+    </div>
+  ),
+};
+
+// ─── Custom Icon ──────────────────────────────────────────────────────────────
+
+/** icon prop으로 커스텀 아이콘을 제공할 수 있다 */
+export const CustomIcon: Story = {
+  render: () => (
+    <Button
+      onClick={() =>
+        toast('커스텀 아이콘 토스트', {
+          description: '이모지도 아이콘으로 사용할 수 있습니다.',
+          icon: (
+            <span style={{ fontSize: 16, lineHeight: 1 }}>🎉</span>
+          ),
+        })
+      }
+    >
+      커스텀 아이콘
+    </Button>
+  ),
+};
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+/** 5가지 타입을 한 번에 띄워 색상 차이를 확인한다 */
+export const AllTypes: Story = {
+  render: () => (
+    <Button
+      onClick={() => {
+        toast('기본 알림');
+        toast.success('성공');
+        toast.error('오류');
+        toast.warning('주의');
+        toast.info('안내');
+      }}
+    >
+      모든 타입 띄우기
+    </Button>
+  ),
+};
+
+// ─── Manual Dismiss ───────────────────────────────────────────────────────────
+
+/** duration: Infinity + dismissible=true — 닫기 버튼을 눌러야만 사라진다 */
+export const ManualDismiss: Story = {
+  render: () => (
+    <Button
+      onClick={() =>
+        toast.success('직접 닫아야 사라집니다', {
+          duration: Infinity,
+          dismissible: true,
+        })
+      }
+    >
+      수동 닫기 토스트
+    </Button>
+  ),
+};
+
+// ─── Dismiss by ID ────────────────────────────────────────────────────────────
+
+/** toast()가 반환하는 id로 외부에서 특정 토스트를 제거할 수 있다 */
+export const DismissById: Story = {
+  render: () => {
+    let id: string | null = null;
+    return (
+      <div className="flex gap-2">
+        <Button
+          onClick={() => {
+            id = toast('5초짜리 토스트', { duration: 5000 });
+          }}
+        >
+          토스트 띄우기
+        </Button>
+        <Button
+          variant="outline"
+          onClick={() => {
+            if (id) toast.dismiss(id);
+          }}
+        >
+          즉시 제거
+        </Button>
+      </div>
+    );
+  },
+};
+
+// ─── Stack ────────────────────────────────────────────────────────────────────
+
+/** 여러 토스트가 쌓이는 모습. maxToasts(기본 5) 초과 시 오래된 것이 숨겨진다 */
+export const Stack: Story = {
+  render: () => (
+    <Button
+      onClick={() => {
+        toast.success('첫 번째');
+        toast.info('두 번째');
+        toast.warning('세 번째');
+        toast.error('네 번째');
+        toast('다섯 번째');
+      }}
+    >
+      5개 한번에 띄우기
+    </Button>
+  ),
+};
+
+// ─── Positions ────────────────────────────────────────────────────────────────
+
+/**
+ * Controls 패널에서 position을 바꿔가며 위치를 확인한다.
+ * Storybook 우측 Controls → position 드롭다운 선택
+ */
+export const Positions: Story = {
+  render: () => (
+    <Button onClick={() => toast.success('위치 확인용 토스트')}>
+      토스트 띄우기
+    </Button>
+  ),
+};

--- a/packages/ui/src/components/toast/toast.ts
+++ b/packages/ui/src/components/toast/toast.ts
@@ -1,0 +1,57 @@
+/**
+ * toast() 공개 API
+ *
+ * store.addToast()의 편의 래퍼.
+ * 함수이면서 동시에 메서드를 가지는 구조:
+ *
+ *   toast("제목")                                        — default 타입
+ *   toast("제목", { description: "설명" })
+ *   toast.success("저장됨")
+ *   toast.error("오류", { description: "...", dismissible: true })
+ *   toast.warning("주의")
+ *   toast.info("안내")
+ *   toast.dismiss(id)                                    — 수동 제거
+ *
+ * 반환값: 생성된 toast의 id (dismiss에 활용 가능)
+ */
+
+import { store } from './store';
+import type { ToastOptions } from './types';
+
+function createToast(
+  title: string,
+  options: ToastOptions = {},
+): string {
+  const id = crypto.randomUUID();
+  store.addToast({ id, title, createdAt: Date.now(), ...options });
+  return id;
+}
+
+function toastFn(title: string, options?: ToastOptions): string {
+  return createToast(title, options);
+}
+
+toastFn.success = (
+  title: string,
+  options?: Omit<ToastOptions, 'type'>,
+): string => createToast(title, { ...options, type: 'success' });
+
+toastFn.error = (
+  title: string,
+  options?: Omit<ToastOptions, 'type'>,
+): string => createToast(title, { ...options, type: 'error' });
+
+toastFn.warning = (
+  title: string,
+  options?: Omit<ToastOptions, 'type'>,
+): string => createToast(title, { ...options, type: 'warning' });
+
+toastFn.info = (
+  title: string,
+  options?: Omit<ToastOptions, 'type'>,
+): string => createToast(title, { ...options, type: 'info' });
+
+/** id로 특정 토스트를 즉시 제거 */
+toastFn.dismiss = (id: string): void => store.removeToast(id);
+
+export const toast = toastFn;

--- a/packages/ui/src/components/toast/toaster.tsx
+++ b/packages/ui/src/components/toast/toaster.tsx
@@ -17,7 +17,6 @@
 
 import { useCallback, useSyncExternalStore } from 'react';
 import { createPortal } from 'react-dom';
-import { AnimatePresence } from 'motion/react';
 import { cn } from '../../lib/cn';
 import { store } from './store';
 import { ToastItem } from './toast-item';
@@ -85,15 +84,13 @@ export function Toaster({
         positionClasses[position],
       )}
     >
-      <AnimatePresence initial={false}>
-        {visibleToasts.map((t) => (
-          <ToastItem
-            key={t.id}
-            toast={t}
-            defaultDuration={defaultDuration}
-          />
-        ))}
-      </AnimatePresence>
+      {visibleToasts.map((t) => (
+        <ToastItem
+          key={t.id}
+          toast={t}
+          defaultDuration={defaultDuration}
+        />
+      ))}
     </div>,
     body,
   );

--- a/packages/ui/src/components/toast/toaster.tsx
+++ b/packages/ui/src/components/toast/toaster.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+/**
+ * Toaster — 토스트 컨테이너 컴포넌트
+ *
+ * 역할:
+ *   - useSyncExternalStore로 store 구독 (useEffect 불필요)
+ *   - createPortal로 document.body에 직접 렌더 (z-index 충돌 / layout 영향 없음)
+ *   - position에 따라 화면 위치 결정
+ *   - maxToasts 초과분 잘라내기 (오래된 것부터 숨김)
+ *
+ * 사용법:
+ *   앱 최상단에 한 번만 배치한다. Provider 불필요.
+ *
+ *   <Toaster position="bottom-right" />
+ */
+
+import { useCallback, useSyncExternalStore } from 'react';
+import { createPortal } from 'react-dom';
+import { AnimatePresence } from 'motion/react';
+import { cn } from '../../lib/cn';
+import { store } from './store';
+import { ToastItem } from './toast-item';
+import type { Toast, ToastPosition, ToasterProps } from './types';
+
+/** 포지션 → Tailwind fixed 클래스 맵핑 */
+const positionClasses: Record<ToastPosition, string> = {
+  'top-left': 'top-4 left-4 items-start',
+  'top-center': 'top-4 left-1/2 -translate-x-1/2 items-center',
+  'top-right': 'top-4 right-4 items-end',
+  'bottom-left': 'bottom-4 left-4 items-start',
+  'bottom-center': 'bottom-4 left-1/2 -translate-x-1/2 items-center',
+  'bottom-right': 'bottom-4 right-4 items-end',
+};
+
+/**
+ * document.body SSR 여부 확인용 no-op subscriber.
+ * useSyncExternalStore의 server snapshot에서 null을 반환해 SSR 시 portal을 건너뛴다.
+ */
+const noopSubscribe = () => () => {};
+
+export function Toaster({
+  position = 'bottom-right',
+  maxToasts = 5,
+  defaultDuration = 4000,
+}: ToasterProps) {
+  // store.subscribe는 (toasts: Toast[]) => void 형태이므로,
+  // useSyncExternalStore가 요구하는 () => void 형태로 래핑한다.
+  const subscribe = useCallback(
+    (onStoreChange: () => void) =>
+      store.subscribe(() => onStoreChange()),
+    [],
+  );
+
+  const toasts = useSyncExternalStore<Toast[]>(
+    subscribe,
+    store.getToasts,
+    () => [], // SSR snapshot: 서버에서는 빈 배열
+  );
+
+  // SSR 안전: server에서는 null, client에서만 document.body 반환
+  const body = useSyncExternalStore(
+    noopSubscribe,
+    () => document.body,
+    () => null,
+  );
+
+  if (!body) return null;
+
+  // 스택 순서:
+  //   bottom-* → 최신 토스트가 하단(코너 방향)에 위치 → 배열 끝 N개 사용
+  //   top-*    → 최신 토스트가 상단(코너 방향)에 위치 → 배열 뒤집어서 앞 N개 사용
+  const isBottom = position.startsWith('bottom');
+  const visibleToasts = isBottom
+    ? toasts.slice(-maxToasts)
+    : [...toasts].reverse().slice(0, maxToasts);
+
+  return createPortal(
+    <div
+      data-toast-container
+      className={cn(
+        'fixed z-50 flex flex-col gap-2 w-full max-w-sm pointer-events-none',
+        // pointer-events-none: 컨테이너 자체는 클릭 통과
+        // 각 ToastItem은 내부적으로 pointer-events-auto 적용
+        positionClasses[position],
+      )}
+    >
+      <AnimatePresence initial={false}>
+        {visibleToasts.map((t) => (
+          <ToastItem
+            key={t.id}
+            toast={t}
+            defaultDuration={defaultDuration}
+          />
+        ))}
+      </AnimatePresence>
+    </div>,
+    body,
+  );
+}

--- a/packages/ui/src/components/toast/types.ts
+++ b/packages/ui/src/components/toast/types.ts
@@ -1,0 +1,48 @@
+export type ToastType =
+  | 'default'
+  | 'success'
+  | 'error'
+  | 'warning'
+  | 'info';
+
+export type ToastPosition =
+  | 'top-left'
+  | 'top-center'
+  | 'top-right'
+  | 'bottom-left'
+  | 'bottom-center'
+  | 'bottom-right';
+
+export interface Toast {
+  id: string;
+  /** 토스트 제목 (필수) */
+  title: string;
+  /** 부가 설명 (선택) */
+  description?: string;
+  /** 좌측 커스텀 아이콘. 없으면 type 아이콘으로 대체 */
+  icon?: React.ReactNode;
+  type?: ToastType;
+  /** ms. Infinity = 수동 닫기. 기본값: defaultDuration */
+  duration?: number;
+  /** 생성 시각 (Date.now()). 숨겨졌다 다시 나타날 때 남은 시간 계산에 사용 */
+  createdAt: number;
+  /** true 일 때만 닫기 버튼 표시 */
+  dismissible?: boolean;
+}
+
+export interface ToastOptions {
+  duration?: number;
+  type?: ToastType;
+  description?: string;
+  icon?: React.ReactNode;
+  dismissible?: boolean;
+}
+
+export interface ToasterProps {
+  /** 기본값: 'bottom-right' */
+  position?: ToastPosition;
+  /** 동시 표시 최대 개수. 기본값: 5 */
+  maxToasts?: number;
+  /** 자동 소멸 시간(ms). 기본값: 4000 */
+  defaultDuration?: number;
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -47,5 +47,15 @@ export type {
   ThemeProviderProps,
 } from './theme';
 
+// Toast
+export { toast, Toaster } from './components/toast';
+export type {
+  Toast,
+  ToastOptions,
+  ToastType,
+  ToastPosition,
+  ToasterProps,
+} from './components/toast';
+
 // Utils
 export { cn } from './lib/cn';

--- a/packages/ui/src/theme/theme.css
+++ b/packages/ui/src/theme/theme.css
@@ -108,3 +108,20 @@
   --color-input: oklch(0.27 0 0);
   --color-ring: oklch(0.98 0 0);
 }
+
+/* ==================== Animations ==================== */
+
+@keyframes toast-enter {
+  from { opacity: 0; transform: translateY(0.5rem) scale(0.96); }
+  to   { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+@keyframes toast-exit {
+  from { opacity: 1; transform: translateY(0) scale(1); }
+  to   { opacity: 0; transform: translateY(0.5rem) scale(0.96); }
+}
+
+@theme {
+  --animate-toast-enter: toast-enter 0.2s ease-out;
+  --animate-toast-exit: toast-exit 0.3s ease-in forwards;
+}

--- a/packages/ui/tsup.config.ts
+++ b/packages/ui/tsup.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     'src/index.ts',
     'src/components/button/button.tsx',
     'src/components/image-uploader/image-uploader.tsx',
+    'src/components/toast/toaster.tsx',
     'src/theme/index.ts',
     'src/lib/cn.ts',
   ],


### PR DESCRIPTION
## 🐕 PR 개요

@poodle-kit/ui에 Toast 컴포넌트를 신규 추가합니다.

React Context 없이 모듈 레벨 store를 통해 어디서든 toast() 함수를 호출할 수 있으며, <Toaster />를 앱 루트에 한 번만 배치하면 동작합니다.

## 🦮 변경 유형

<!-- 해당하는 항목에 'x'를 표시해주세요 (복수 선택 가능) -->

- [x] ✨ 신규 컴포넌트 추가
- [ ] 🎨 기존 컴포넌트 UI/UX 개선
- [ ] 🧠 로직 변경 / 상태 관리 수정
- [ ] 🐛 버그 수정
- [ ] ♻️ 리팩토링 (기능 변경 없음)
- [ ] 🧪 테스트 추가/수정
- [ ] 🔧 설정 파일 변경 (빌드, 린트, 테스트 등)
- [ ] 🏗️ 프로젝트 구조 변경
- [ ] 🚀 배포/릴리즈 관련 작업

## 🐩 주요 변경 사항

### 핵심 로직 (store.ts, toast.ts, types.ts)

- 모듈 레벨 변수로 토스트 상태를 관리하는 store 구현 (useSyncExternalStore 기반)
- Provider 없이 어디서든 호출 가능한 toast() 공개 API 추가

```tsx
toast(title)
toast.success()
toast.error()
toast.warning()
toast.info()
toast.dismiss(id)
```

- toast 생성 시 id를 반환하여 외부에서 직접 제어 가능
- createdAt 기준으로 경과 시간을 계산하여, hidden 상태였다가 다시 표시되는 경우에도 남은 시간만큼만 자동 소멸

---

### UI 컴포넌트 (toast-item.tsx, toaster.tsx)

- `<Toaster />`
    - 앱 루트에 1회 배치
    - position / maxToasts / defaultDuration props 지원
    - createPortal로 document.body에 렌더링하여 z-index 및 layout 영향 제거
- `<ToastItem />`
    - type별 아이콘 자동 적용 (icon prop 우선)
    - description, dismissible 닫기 버튼 지원
    - role="alert" 등 접근성 속성 적용

---

### 애니메이션 처리

- framer-motion 없이 CSS @keyframes 기반으로 구현
- mount → enter 애니메이션
- dismiss → exit 애니메이션 후 제거

→ 별도 라이브러리 없이 동일 UX를 제공하면서 번들 크기 최소화

---

### 스택 및 표시 방식

- maxToasts 기준으로 화면에 표시되는 개수 제한
- 초과된 토스트는 제거하지 않고 hidden 상태로 유지

동작 흐름:

```
visible 토스트 제거
↓
hidden 토스트가 앞으로 이동 (승격)
↓
남은 duration만큼 표시 후 자동 제거
```

→ 대기 중이던 토스트도 자연스럽게 이어서 표시됨

---

### 설정 및 테마

- packages/ui/src/theme/theme.css에 toast 애니메이션 변수 추가
- tsup.config.ts에 toast 엔트리 포인트 추가 (toaster 분리)
- packages/ui/src/index.ts에서 toast, Toaster, 타입 re-export

---

### 스토리북

- 모든 type / position / 옵션 조합을 커버하는 스토리 추가

## 🐕‍🦺 테스트 정보

- 버튼 클릭 시 토스트 표시 여부
- 자동 소멸 (기본 duration)
- dismiss 버튼 동작
- position 6종 정상 동작
- maxToasts 초과 시 스택 동작 확인
- [ ] 단위 테스트 추가/수정
- [x] 스토리북 확인
- [x] 로컬 환경에서 직접 테스트
- [ ] 테스트 없음 (사유를 아래에 작성)

### 테스트 방법

<!-- 리뷰어가 그대로 따라 할 수 있도록 작성해주세요 -->

1. `pnpm storybook` 실행
2. Toast 카테고리에서 각 스토리(Default, Success, Error, Warning, Info, Positions, Dismissible 등) 확인

## 🦴 체크리스트

<!-- PR 제출 전 반드시 확인해주세요 -->

- [x] 로컬에서 빌드가 정상적으로 완료됨
- [x] lint / typecheck 오류 없음
- [ ] 테스트가 모두 통과함
- [x] 기존 기능에 영향을 주지 않음 (또는 영향 범위 명시)
- [ ] 불필요한 console.log, 주석 제거
- [x] 네이밍 및 코드 컨벤션 준수

## 🐶 스크린샷 / 미리보기

<!-- UI 변경이 있는 경우 첨부해주세요 -->

### Before

### After

## 🦴 추가 정보    
- useSyncExternalStore를 사용한 이유
    
    → React 외부 store와의 동기화를 보장하며 Concurrent Mode에서 tearing 방지
    
- Provider 없이 구현한 이유
    
    → 모듈 레벨 상태를 사용하여 React 트리와 무관하게 어디서든 toast 호출 가능
 

## 🦴 향후 작업
- 액션버튼
- 반응형 대응

## 🐾 관련 이슈 / PR

<!-- 관련 이슈나 선행/후속 PR이 있다면 링크해주세요 -->

Closes #21 

---
참고 글
https://inpa.tistory.com/entry/GOF-%F0%9F%92%A0-%EC%98%B5%EC%A0%80%EB%B2%84Observer-%ED%8C%A8%ED%84%B4-%EC%A0%9C%EB%8C%80%EB%A1%9C-%EB%B0%B0%EC%9B%8C%EB%B3%B4%EC%9E%90

https://devowen.com/518

노션 기록: https://www.notion.so/dreampaste/toast-3274a578ed6d801fb463e17c9c9aed02?source=copy_link